### PR TITLE
Fix wrong curseTypes check

### DIFF
--- a/src/classes/features/StartNewRun.ts
+++ b/src/classes/features/StartNewRun.ts
@@ -241,7 +241,7 @@ export class StartNewRun extends ModFeature {
 
     // If the user didn't enable any curse types in particular, enable all of them since that's the
     // game's default behavior.
-    if (enabledCurseTypes.size > 0) {
+    if (enabledCurseTypes.size === 0) {
       enabledCurseTypes.add(LevelCurse.BLIND);
       enabledCurseTypes.add(LevelCurse.DARKNESS);
       enabledCurseTypes.add(LevelCurse.LABYRINTH);


### PR DESCRIPTION
Currently, the code always enables all curse types, due to a mistake in the code.